### PR TITLE
Add Github Action CI to compile the Firmware

### DIFF
--- a/.github/workflows/opensmartmeter.yaml
+++ b/.github/workflows/opensmartmeter.yaml
@@ -1,0 +1,27 @@
+name: OpenSmartMeter
+
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+    branches:
+      - main
+
+jobs:
+  compile-firmware:
+    name: Compile Firmware
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - name: Install Arduino CLI
+        uses: arduino/setup-arduino-cli@v1
+      - name: Install board and platform
+        working-directory: Firmware code/smart_energy_meter
+        run: |
+          arduino-cli core update-index --additional-urls https://github.com/stm32duino/BoardManagerFiles/raw/master/STM32/package_stm_index.json
+          arduino-cli core install STM32:stm32@1.9.0 --additional-urls https://github.com/stm32duino/BoardManagerFiles/raw/master/STM32/package_stm_index.json
+      - name: Compile the firmware
+        working-directory: Firmware code/smart_energy_meter
+        run: |
+          arduino-cli compile --fqbn "STM32:stm32:GenF1:pnum=BLUEPILL_F103C8" --libraries=Library/


### PR DESCRIPTION
Very basic version of CI. Just to ensure the Firmware actually compiles.

Board, board part, platform and FQBN are currently hardcoded in the action. In the future we can maybe read this from a shared configuration file.