### PR TITLE
Move `relay` module to HPP file

### DIFF
--- a/Firmware code/smart_energy_meter/relay.hpp
+++ b/Firmware code/smart_energy_meter/relay.hpp
@@ -1,3 +1,17 @@
+#pragma once
+
+// defines
+
+// Arduino base libraries
+
+// third party libraries
+
+// OpenSmartMeter libraries
+#include "global_defines.hpp"
+
+byte off_exec = 0;
+byte on_exec = 0;
+
 void relay_on() {
   if (on_exec == 0) {
     digitalWrite(relaya, HIGH);

--- a/Firmware code/smart_energy_meter/smart_energy_meter.ino
+++ b/Firmware code/smart_energy_meter/smart_energy_meter.ino
@@ -22,6 +22,7 @@
 // OpenSmartMeter libraries
 #include "SAM_UART.h"
 #include "global_defines.hpp"
+#include "relay.hpp"
 
 HardwareSerial Serial2(PA3, PA2);
 HardwareSerial ATM90E26(PB11, PB10);
@@ -109,8 +110,6 @@ unsigned long sts_value, convertedsts_day, pulsetime, current_time, previous,
     previousenergytime, previousenergytime2, energytime, energytime2,
     currentenergytime, currentenergytime2 = 0;
 byte get_credit, fault, fault_written = 0;
-byte off_exec = 0;
-byte on_exec = 0;
 int confirmkey, tamper_log = 0;
 byte token_used, thingsboard_check = 0;
 


### PR DESCRIPTION
This PR moves the `relay.ino` file to a `relay.hpp`. It essentially makes sure all variables are in-scope.