### PR TITLE
Add back call to `RPC_Subscribe`

### DIFF
--- a/Firmware code/smart_energy_meter/thingsboard.ino
+++ b/Firmware code/smart_energy_meter/thingsboard.ino
@@ -40,7 +40,10 @@ void post_to_thingsboard() {
 void reconnect() {
   while (!tb.connected()) {
     if (tb.connect(THINGSBOARD_SERVER, TOKEN)) {
-      //    tb.RPC_subscribe();
+      // subscribe without callbacks
+      RPC_Callback callbacks[0] = {};
+      tb.RPC_Subscribe(callbacks, 0);
+
       lcd.setCursor(0, 0);
       lcd.print("  reconnected   ");
     } else {


### PR DESCRIPTION
The customized version `RPC_subscribe` was calling `subscribe` of the underlying Pub/Sub client. We can achieve the same behaviour by calling `tb.RPC_Subscribe` with an empty callback array.

Resolves: #15 