### PR TITLE
Silence some library warnings

### DIFF
--- a/Firmware code/smart_energy_meter/platformio.ini
+++ b/Firmware code/smart_energy_meter/platformio.ini
@@ -25,6 +25,11 @@ board = bluepill_f103c8_128k
 upload_protocol = serial
 monitor_speed = 115200
 
+build_flags =
+    -Wno-deprecated-declarations  # silence warnings from PubSubClient
+    -Wno-logical-not-parentheses  # silence warnings from ArduinoHttpClient
+    -Wno-sequence-point  # silence warnings from RTClib
+
 lib_deps =
     arduino-libraries/ArduinoHttpClient@0.4.0
     bblanchon/ArduinoJson@6.20.1


### PR DESCRIPTION
Currently, `pio run` produces a whole lot of noise. Here we are silencing some of the warnings.