### PR TITLE
Enable Github pages with `MkDocs`

### DIFF
--- a/.github/workflows/mkdocs-gh-pages.yaml
+++ b/.github/workflows/mkdocs-gh-pages.yaml
@@ -1,0 +1,54 @@
+# Sample workflow for building and deploying a Jekyll site to GitHub Pages
+name: Deploy GitHub Pages with MkDocs
+
+on:
+  # Runs on pushes targeting the default branch
+  push:
+    branches: ["main"]
+
+  # Allows you to run this workflow manually from the Actions tab
+  workflow_dispatch:
+
+# Sets permissions of the GITHUB_TOKEN to allow deployment to GitHub Pages
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+# Allow one concurrent deployment
+concurrency:
+  group: "pages"
+  cancel-in-progress: true
+
+jobs:
+  # Build job
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+      - name: Setup Pages
+        uses: actions/configure-pages@v2
+      - uses: "actions/setup-python@v3"
+        with:
+            python-version: "3.10"
+      - name: Install MkDocs
+        run: "pip install mkdocs mkdocs-material"
+      - name: Build with MkDocs
+        run: mkdocs build
+      - name: Upload artifact
+        uses: actions/upload-pages-artifact@v1
+        with:
+          path: "site/"
+
+  # Deployment job
+  deploy:
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    runs-on: ubuntu-latest
+    needs: build
+    steps:
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@v1

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,0 +1,17 @@
+# Welcome to MkDocs
+
+For full documentation visit [mkdocs.org](https://www.mkdocs.org).
+
+## Commands
+
+* `mkdocs new [dir-name]` - Create a new project.
+* `mkdocs serve` - Start the live-reloading docs server.
+* `mkdocs build` - Build the documentation site.
+* `mkdocs -h` - Print help message and exit.
+
+## Project layout
+
+    mkdocs.yml    # The configuration file.
+    docs/
+        index.md  # The documentation homepage.
+        ...       # Other markdown pages, images and other files.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -1,0 +1,20 @@
+# Project information
+site_name: OpenSmartMeter by EnAccess
+site_url: https://enaccess.github.io/OpenSmartMeter/
+site_description: >-
+  This is the documentation for the OpenSmartMeter by EnAccess
+
+# Repository
+repo_name: EnAccess/OpenSmartMeter
+repo_url: https://github.com/EnAccess/OpenSmartMeter
+
+theme:
+  name: material
+
+# Customization
+extra:
+  social:
+    - icon: fontawesome/brands/github
+      link: https://github.com/EnAccess
+    - icon: fontawesome/brands/twitter
+      link: https://twitter.com/enaccessfdn


### PR DESCRIPTION
Boilerplate setup to use Github Pages with `MkDocs`