### PR TITLE
Add `opaygo_decoder`

### DIFF
--- a/.github/workflows/opensmartmeter.yaml
+++ b/.github/workflows/opensmartmeter.yaml
@@ -16,7 +16,7 @@ jobs:
       - uses: actions/checkout@v3
       - name: Run clang-format lint
         working-directory: Firmware code/smart_energy_meter
-        run: find include/ lib/ src/ \( -name '*.[ch]pp' -o -name '*.h' \) | xargs clang-format --verbose --style=file -n --Werror
+        run: find include/ src/ \( -name '*.[ch]pp' -o -name '*.h' \) | xargs clang-format --verbose --style=file -n --Werror
   editorconfig-checker:
     name: Lint EditorConfig
     runs-on: ubuntu-latest

--- a/.github/workflows/opensmartmeter.yaml
+++ b/.github/workflows/opensmartmeter.yaml
@@ -28,7 +28,7 @@ jobs:
       - run: 'pip install "editorconfig-checker"'
       - name: Run editorconfig-checker
         working-directory: Firmware code/smart_energy_meter
-        run: ec
+        run: ec -exclude lib/
   compile-firmware-platform-io:
     name: Compile Firmware with PlatformIO
     runs-on: ubuntu-latest

--- a/Firmware code/smart_energy_meter/lib/opaygo_decoder/extended/opaygo_core_extended.c
+++ b/Firmware code/smart_energy_meter/lib/opaygo_decoder/extended/opaygo_core_extended.c
@@ -1,0 +1,64 @@
+//
+//  opaygo_core_extended.c
+//  OPAYGO-Unix
+//
+//  Created by Benjamin David on 17/09/2019.
+//  Copyright © 2019 Solaris Offgrid. All rights reserved.
+//
+
+#include "opaygo_core_extended.h"
+
+#include "opaygo_core.h"
+#include "siphash.h"
+
+
+uint64_t extractBitsExtended(uint64_t source, unsigned from, unsigned to)
+{
+    unsigned long long mask = ( (1ull<<(to-from+1ull))-1ull) << from;
+    return (source & mask) >> 24;
+}
+
+uint64_t ConvertHashToTokenExtended(uint64_t this_hash) {
+    // We reduce it to 40 bits
+    uint64_t result = extractBitsExtended(this_hash, 24, 64);
+    // We reduce it to 39.5bits
+    if(result > 999999999999) {
+        result = result - 99511627777;
+    }
+    return result;
+}
+
+uint64_t GenerateOPAYGOTokenExtended(uint64_t LastToken, char SECRET_KEY[16]) {
+    
+    uint8_t a[8];
+    
+    a[0] = LastToken >> 56;
+    a[1] = LastToken >> 48;
+    a[2] = LastToken >> 40;
+    a[3] = LastToken >> 32;
+    a[4] = LastToken >> 24;
+    a[5] = LastToken >> 16;
+    a[6] = LastToken >>  8;
+    a[7] = LastToken;
+    
+    uint64_t ThisHash = siphash24(a, 8, SECRET_KEY);
+    
+    // We return the conformed token
+    return ConvertHashToTokenExtended(ThisHash);
+}
+
+uint32_t DecodeBaseExtended(uint32_t StartingCodeBase, uint32_t TokenBase) {
+    if(TokenBase < StartingCodeBase) {
+        return TokenBase + 1000000 - StartingCodeBase;
+    } else {
+        return TokenBase - StartingCodeBase;
+    }
+}
+
+uint32_t GetTokenBaseExtended(uint64_t Token) {
+    return (Token % 1000000);
+}
+
+uint64_t PutBaseInTokenExtended(uint64_t Token, uint32_t TokenBase) {
+    return Token - (Token % 1000000) + TokenBase;
+}

--- a/Firmware code/smart_energy_meter/lib/opaygo_decoder/extended/opaygo_core_extended.h
+++ b/Firmware code/smart_energy_meter/lib/opaygo_decoder/extended/opaygo_core_extended.h
@@ -1,0 +1,24 @@
+//
+//  opaygo_core_extended.h
+//  OPAYGO-Unix
+//
+//  Created by Benjamin David on 17/09/2019.
+//  Copyright © 2019 Solaris Offgrid. All rights reserved.
+//
+
+#ifndef opaygo_core_extended_h
+#define opaygo_core_extended_h
+
+#if (defined(__APPLE__) && defined(__MACH__)) /* MacOS X Framework build */
+    #include <sys/types.h>
+#endif
+
+#include <stdint.h>
+#include <stdio.h>
+
+uint64_t GenerateOPAYGOTokenExtended(uint64_t LastToken, char SECRET_KEY[16]);
+uint32_t DecodeBaseExtended(uint32_t StartingCodeBase, uint32_t TokenBase);
+uint32_t GetTokenBaseExtended(uint64_t Token);
+uint64_t PutBaseInTokenExtended(uint64_t Token, uint32_t TokenBase);
+
+#endif /* opaygo_core_extended_h */

--- a/Firmware code/smart_energy_meter/lib/opaygo_decoder/extended/opaygo_decoder_extended.c
+++ b/Firmware code/smart_energy_meter/lib/opaygo_decoder/extended/opaygo_decoder_extended.c
@@ -1,0 +1,38 @@
+//
+//  opaygo_decoder_extended.c
+//  OPAYGO-Unix
+//
+//  Created by Benjamin David on 17/09/2019.
+//  Copyright © 2019 Solaris Offgrid. All rights reserved.
+//
+
+#include "opaygo_decoder_extended.h"
+
+
+int32_t GetActivationValueFromExtendedToken(uint64_t InputToken, uint16_t *MaxCount, uint32_t StartingCode, char SECRET_KEY[16]) {
+    
+    uint32_t StartingCodeBase = GetTokenBaseExtended(StartingCode);
+    uint32_t TokenBase = GetTokenBaseExtended(InputToken);
+    uint64_t CurrentToken = PutBaseInTokenExtended(StartingCode, TokenBase);
+    uint64_t MaskedToken;
+    int MaxCountTry;
+    
+    int32_t Value = (int32_t)DecodeBaseExtended(StartingCodeBase, TokenBase);
+    
+    if(Value == COUNTER_SYNC_VALUE) {
+        MaxCountTry = *MaxCount + MAX_TOKEN_JUMP_COUNTER_SYNC;
+    } else {
+        MaxCountTry = *MaxCount + MAX_TOKEN_JUMP;
+    }
+    
+    for (int Count=0; Count <= MaxCountTry; Count++) {
+        MaskedToken = PutBaseInTokenExtended(CurrentToken, TokenBase);
+        if(MaskedToken == InputToken && Count > *MaxCount) {
+            *MaxCount = Count;
+            return Value;
+        }
+        CurrentToken = GenerateOPAYGOTokenExtended(CurrentToken, SECRET_KEY);
+    }
+    
+    return -1;
+}

--- a/Firmware code/smart_energy_meter/lib/opaygo_decoder/extended/opaygo_decoder_extended.h
+++ b/Firmware code/smart_energy_meter/lib/opaygo_decoder/extended/opaygo_decoder_extended.h
@@ -1,0 +1,23 @@
+//
+//  opaygo_decoder_extended.h
+//  OPAYGO-Unix
+//
+//  Created by Benjamin David on 17/09/2019.
+//  Copyright © 2019 Solaris Offgrid. All rights reserved.
+//
+
+#ifndef opaygo_decoder_extended_h
+#define opaygo_decoder_extended_h
+
+#if (defined(__APPLE__) && defined(__MACH__)) /* MacOS X Framework build */
+    #include <sys/types.h>
+#endif
+
+#include <stdint.h>
+#include <stdio.h>
+#include "opaygo_core_extended.h"
+#include "opaygo_decoder.h"
+
+int32_t GetActivationValueFromExtendedToken(uint64_t InputToken, uint16_t *MaxCount, uint32_t StartingCode, char SECRET_KEY[16]);
+
+#endif /* opaygo_decoder_extended_h */

--- a/Firmware code/smart_energy_meter/lib/opaygo_decoder/opaygo_core.c
+++ b/Firmware code/smart_energy_meter/lib/opaygo_decoder/opaygo_core.c
@@ -1,0 +1,45 @@
+#include "opaygo_core.h"
+#include "siphash.h"
+
+
+uint32_t extractBits(uint32_t source, unsigned from, unsigned to)
+{
+    uint32_t  mask = ( (1<<(to-from+1))-1) << from;
+    return (source & mask) >> from;
+}
+
+uint32_t ConvertHashToToken(uint64_t this_hash) {
+    // We split the hash in two parts
+    uint32_t hi_hash, lo_hash;
+    hi_hash = this_hash >> 32;
+    lo_hash = this_hash & 0xFFFFFFFF;
+
+    // We XOR the two halves together
+    hi_hash ^= lo_hash;
+
+    // We reduce it to 30 bits
+    uint32_t result = extractBits(hi_hash, 2, 32);
+    // We reduce it to 29.5bits
+    if(result > 999999999) {
+        result = result - 73741825;
+    }
+    return result;
+}
+
+uint32_t GenerateOPAYGOToken(uint32_t LastToken, unsigned char SECRET_KEY[16]) {
+    uint8_t a[8];
+
+    a[0] = LastToken >> 24;
+    a[1] = LastToken >> 16;
+    a[2] = LastToken >>  8;
+    a[3] = LastToken;
+    a[4] = LastToken >> 24;
+    a[5] = LastToken >> 16;
+    a[6] = LastToken >>  8;
+    a[7] = LastToken;
+
+    uint64_t ThisHash = siphash24(a, 8, SECRET_KEY);
+
+    // We return the conformed token
+    return ConvertHashToToken(ThisHash);
+}

--- a/Firmware code/smart_energy_meter/lib/opaygo_decoder/opaygo_core.h
+++ b/Firmware code/smart_energy_meter/lib/opaygo_decoder/opaygo_core.h
@@ -1,0 +1,17 @@
+#ifndef opaygo_core_h
+#define opaygo_core_h
+
+#if (defined(__APPLE__) && defined(__MACH__)) /* MacOS X Framework build */
+    #include <sys/types.h>
+#endif
+
+#include <stdint.h>
+#include <stdio.h>
+
+#define MAX_ACTIVATION_VALUE 995
+#define PAYG_DISABLE_VALUE 998
+#define COUNTER_SYNC_VALUE 999
+
+uint32_t GenerateOPAYGOToken(uint32_t LastToken, unsigned char SECRET_KEY[16]);
+
+#endif

--- a/Firmware code/smart_energy_meter/lib/opaygo_decoder/opaygo_decoder.c
+++ b/Firmware code/smart_energy_meter/lib/opaygo_decoder/opaygo_decoder.c
@@ -1,0 +1,112 @@
+#include "opaygo_decoder.h"
+
+#define CHECK_BIT(variable, position) ((variable) & (1<<(position)))
+#define SET_BIT(variable,position,value) (variable & ~(1<<position)) | (value<<position)
+
+
+bool IsInUsedCounts(int Count, uint16_t MaxCount, uint16_t UsedCounts) {
+    uint16_t RelativeCount = MaxCount - Count - 1;
+    if(Count % 2 && Count <= MaxCount) {
+        return true;
+    }
+    if(CHECK_BIT(UsedCounts, RelativeCount) || Count == MaxCount) {
+        return true;
+    }
+    return false;
+}
+
+bool IsCountValid(int Count, uint16_t MaxCount, int Value, uint16_t UsedCounts) {
+    if(Value == COUNTER_SYNC_VALUE) {
+        // We don't need to check if it's below the max as those tokens aren't tried anyway
+        if (Count > MaxCount - MAX_TOKEN_JUMP) {
+            return true;
+        }
+    } else if (Count > MaxCount) {
+        return true;
+    } else if(MAX_UNUSED_OLDER_TOKENS > 0 && Count != 0) {
+        // We check that the count is in the range for unused older token or above
+        if (Count > MaxCount - MAX_UNUSED_OLDER_TOKENS) {
+            // If it is, we check that its ADD_CREDIT and that this count was not used
+            if (Count % 2 == 0 && !IsInUsedCounts(Count, MaxCount, UsedCounts)) {
+                return true;
+            }
+        }
+    }
+    return false;
+}
+
+void MarkCountAsUsed(int Count, uint16_t *MaxCount, uint16_t *UsedCounts, int Value) {
+    uint16_t NewUsedCount = 0;
+    if(Count % 2 || Value == COUNTER_SYNC_VALUE || Value == PAYG_DISABLE_VALUE) {
+        // If it was a SET_CREDIT token or it was Counter Sync then we mark all past tokens as used
+        for(int i=0; i < MAX_UNUSED_OLDER_TOKENS; i++) {
+            *UsedCounts = SET_BIT(*UsedCounts, i, 1);
+        }
+    } else {
+        if(Count > *MaxCount) {
+            uint16_t RelativeCount = Count - *MaxCount;
+            if(RelativeCount > MAX_UNUSED_OLDER_TOKENS) {
+                // We cannot mark more tokens as used than the max allowed older tokens
+                RelativeCount = MAX_UNUSED_OLDER_TOKENS;
+            } else {
+                NewUsedCount = SET_BIT(NewUsedCount, (RelativeCount-1), 1);
+            }
+            // We move all of the tokens marked as used to their new position relative to the new max count
+            for(int i=RelativeCount+1; i < MAX_UNUSED_OLDER_TOKENS - RelativeCount; i++) {
+                NewUsedCount = SET_BIT(NewUsedCount, i, CHECK_BIT(*UsedCounts, i-RelativeCount));
+            }
+            *UsedCounts = NewUsedCount;
+        } else {
+            // If the token is older than the max one, we just mark this one as used but don't shift any other tokens
+            *UsedCounts = SET_BIT(*UsedCounts, (*MaxCount - Count - 1), 1);
+        }
+    }
+    if(Count > *MaxCount) {
+        *MaxCount = Count;
+    }
+}
+
+
+TokenData GetDataFromToken(uint64_t InputToken, uint16_t *MaxCount, uint16_t *UsedCounts, uint32_t StartingCode, unsigned char SECRET_KEY[16]) {
+
+#ifdef RESTRICTED_DIGIT_SET_MODE
+    InputToken = ConvertFromFourDigitToken(InputToken);
+#endif
+    uint16_t StartingCodeBase = GetTokenBase(StartingCode);
+    uint16_t TokenBase = GetTokenBase((uint32_t)InputToken);
+    uint32_t CurrentToken = PutBaseInToken(StartingCode, TokenBase);
+    uint32_t MaskedToken;
+    int MaxCountTry;
+    int MinCountTry;
+    int Value = DecodeBase(StartingCodeBase, TokenBase);
+    TokenData output;
+    bool ValidOlderToken = false;
+
+    if(Value == COUNTER_SYNC_VALUE) {
+        MaxCountTry = *MaxCount + MAX_TOKEN_JUMP_COUNTER_SYNC;
+    } else {
+        MaxCountTry = *MaxCount + MAX_TOKEN_JUMP;
+    }
+
+    for (int Count=0; Count <= MaxCountTry; Count++) {
+        MaskedToken = PutBaseInToken(CurrentToken, TokenBase);
+        if(MaskedToken == InputToken) {
+            if(IsCountValid(Count, *MaxCount, Value, *UsedCounts)) {
+                MarkCountAsUsed(Count, MaxCount, UsedCounts, Value);
+                output.Value = Value;
+                output.Count = Count;
+                return output;
+            } else {
+                ValidOlderToken = true;
+            }
+        }
+        CurrentToken = GenerateOPAYGOToken(CurrentToken, SECRET_KEY);
+    }
+    if(ValidOlderToken) {
+        output.Value = -2;
+    } else {
+        output.Value = -1;
+    }
+    output.Count = *MaxCount;
+    return output;
+}

--- a/Firmware code/smart_energy_meter/lib/opaygo_decoder/opaygo_decoder.h
+++ b/Firmware code/smart_energy_meter/lib/opaygo_decoder/opaygo_decoder.h
@@ -1,0 +1,26 @@
+#ifndef opaygo_decoder_h
+#define opaygo_decoder_h
+
+#if (defined(__APPLE__) && defined(__MACH__)) /* MacOS X Framework build */
+    #include <sys/types.h>
+#endif
+
+#include <stdint.h>
+#include <stdio.h>
+#include "opaygo_core.h"
+#include "opaygo_value_utils.h"
+#include "restricted_digit_set_mode.h"
+
+#define MAX_TOKEN_JUMP 64 // This is a jump in count so up to twice as large as the number of tokens of the same type
+#define MAX_TOKEN_JUMP_COUNTER_SYNC 100 // This is a jump in count so up to twice as large as the number of tokens
+#define MAX_UNUSED_OLDER_TOKENS 16 // Maximum of 16 (8 tokens of the same type)
+
+struct TokenDataStruct {
+    int Value;
+    uint16_t Count;
+};
+typedef struct TokenDataStruct TokenData;
+
+TokenData GetDataFromToken(uint64_t InputToken, uint16_t *MaxCount, uint16_t *UsedCounts, uint32_t StartingCode, unsigned char SECRET_KEY[16]);
+
+#endif

--- a/Firmware code/smart_energy_meter/lib/opaygo_decoder/opaygo_value_utils.c
+++ b/Firmware code/smart_energy_meter/lib/opaygo_decoder/opaygo_value_utils.c
@@ -1,0 +1,18 @@
+#include "opaygo_value_utils.h"
+
+
+int DecodeBase(int StartingCodeBase, int TokenBase) {
+    if((TokenBase - StartingCodeBase) < 0) {
+        return TokenBase + 1000 - StartingCodeBase;
+    } else {
+        return TokenBase - StartingCodeBase;
+    }
+}
+
+int GetTokenBase(uint32_t Token) {
+    return (Token % 1000);
+}
+
+uint32_t PutBaseInToken(uint32_t Token, int TokenBase) {
+    return Token - (Token % 1000) + TokenBase;
+}

--- a/Firmware code/smart_energy_meter/lib/opaygo_decoder/opaygo_value_utils.h
+++ b/Firmware code/smart_energy_meter/lib/opaygo_decoder/opaygo_value_utils.h
@@ -1,0 +1,15 @@
+#ifndef opaygo_value_utils_h
+#define opaygo_value_utils_h
+
+#include <stdio.h>
+#include <stdint.h>
+
+#if (defined(__APPLE__) && defined(__MACH__)) /* MacOS X Framework build */
+    #include <sys/types.h>
+#endif
+
+int DecodeBase(int StartingCodeBase, int TokenBase);
+int GetTokenBase(uint32_t Token);
+uint32_t PutBaseInToken(uint32_t Token, int TokenBase);
+
+#endif

--- a/Firmware code/smart_energy_meter/lib/opaygo_decoder/restricted_digit_set_mode.c
+++ b/Firmware code/smart_energy_meter/lib/opaygo_decoder/restricted_digit_set_mode.c
@@ -1,0 +1,33 @@
+#include "restricted_digit_set_mode.h"
+
+void StoreNBitsInArray(bool* BooleanArray, uint64_t Data, uint8_t NumberOfBits, uint8_t BufferStartBit)
+{
+    for (int i = 0; i < NumberOfBits; i++)
+    {
+        BooleanArray[i+BufferStartBit] = !!(Data & (1 << ((NumberOfBits - 1 - i)))); ;
+    }
+}
+
+uint32_t GetINTFromBooleanArray(bool* BooleanArray, uint8_t StartPosition, uint8_t Lenght)
+{
+    uint32_t Buffer = 0;
+    for (int i = StartPosition; i < StartPosition+Lenght; i++) {
+        Buffer = (Buffer << 1) + (BooleanArray[i] ? 1 : 0);
+    }
+    return Buffer;
+}
+
+uint32_t ConvertFromFourDigitToken(uint64_t FourDigitToken) {
+    // This is made for 15 digit long codes converting to 9.
+    // For other lengths the code needs to be adapted
+    bool TokenBooleanArray[30] = {0};
+    uint8_t ThisDigit;
+    
+    for(int i = 0; i < 15; i++) {
+        ThisDigit = (FourDigitToken % 10) - 1;
+        StoreNBitsInArray(TokenBooleanArray, ThisDigit, 2, (14-i)*2);
+        FourDigitToken /= 10;
+    }
+    
+    return GetINTFromBooleanArray(TokenBooleanArray, 0, 30);
+}

--- a/Firmware code/smart_energy_meter/lib/opaygo_decoder/restricted_digit_set_mode.h
+++ b/Firmware code/smart_energy_meter/lib/opaygo_decoder/restricted_digit_set_mode.h
@@ -1,0 +1,14 @@
+#ifndef restricted_digit_set_mode_h
+#define restricted_digit_set_mode_h
+
+#if (defined(__APPLE__) && defined(__MACH__)) /* MacOS X Framework build */
+    #include <sys/types.h>
+#endif
+
+#include <stdint.h>
+#include <stdio.h>
+#include <stdbool.h>
+
+uint32_t ConvertFromFourDigitToken(uint64_t FourDigitToken);
+
+#endif

--- a/Firmware code/smart_energy_meter/lib/opaygo_decoder/siphash.c
+++ b/Firmware code/smart_energy_meter/lib/opaygo_decoder/siphash.c
@@ -1,0 +1,119 @@
+/* <MIT License>
+ Copyright (c) 2013  Marek Majkowski <marek@popcount.org>
+
+ Permission is hereby granted, free of charge, to any person obtaining a copy
+ of this software and associated documentation files (the "Software"), to deal
+ in the Software without restriction, including without limitation the rights
+ to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ copies of the Software, and to permit persons to whom the Software is
+ furnished to do so, subject to the following conditions:
+
+ The above copyright notice and this permission notice shall be included in
+ all copies or substantial portions of the Software.
+
+ THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ THE SOFTWARE.
+ </MIT License>
+
+ Original location:
+    https://github.com/majek/csiphash/
+
+ Solution inspired by code from:
+    Samuel Neves (supercop/crypto_auth/siphash24/little)
+    djb (supercop/crypto_auth/siphash24/little2)
+    Jean-Philippe Aumasson (https://131002.net/siphash/siphash24.c)
+*/
+
+#include <stdint.h>
+
+#if (defined(__APPLE__) && defined(__MACH__)) /* MacOS X Framework build */
+    #include <sys/types.h>
+#endif
+
+#if defined(__BYTE_ORDER__) && defined(__ORDER_LITTLE_ENDIAN__) && \
+	__BYTE_ORDER__ == __ORDER_LITTLE_ENDIAN__
+#  define _le64toh(x) ((uint64_t)(x))
+#elif defined(_WIN32)
+/* Windows is always little endian, unless you're on xbox360
+   http://msdn.microsoft.com/en-us/library/b0084kay(v=vs.80).aspx */
+#  define _le64toh(x) ((uint64_t)(x))
+#elif defined(__APPLE__)
+#  include <libkern/OSByteOrder.h>
+#  define _le64toh(x) OSSwapLittleToHostInt64(x)
+#else
+
+/* See: http://sourceforge.net/p/predef/wiki/Endianness/ */
+#  if defined(__FreeBSD__) || defined(__NetBSD__) || defined(__OpenBSD__)
+#    include <sys/endian.h>
+#  else
+#    include <endian.h>
+#  endif
+#  if defined(__BYTE_ORDER) && defined(__LITTLE_ENDIAN) && \
+	__BYTE_ORDER == __LITTLE_ENDIAN
+#    define _le64toh(x) ((uint64_t)(x))
+#  else
+#    define _le64toh(x) le64toh(x)
+#  endif
+
+#endif
+
+
+#define ROTATE(x, b) (uint64_t)( ((x) << (b)) | ( (x) >> (64 - (b))) )
+
+#define HALF_ROUND(a,b,c,d,s,t)			\
+	a += b; c += d;				\
+	b = ROTATE(b, s) ^ a;			\
+	d = ROTATE(d, t) ^ c;			\
+	a = ROTATE(a, 32);
+
+#define DOUBLE_ROUND(v0,v1,v2,v3)		\
+	HALF_ROUND(v0,v1,v2,v3,13,16);		\
+	HALF_ROUND(v2,v1,v0,v3,17,21);		\
+	HALF_ROUND(v0,v1,v2,v3,13,16);		\
+	HALF_ROUND(v2,v1,v0,v3,17,21);
+
+
+uint64_t siphash24(const void *src, unsigned long src_sz, unsigned char key[16]) {
+	const uint64_t *_key = (uint64_t *)key;
+	uint64_t k0 = _le64toh(_key[0]);
+	uint64_t k1 = _le64toh(_key[1]);
+	uint64_t b = (uint64_t)src_sz << 56;
+	const uint64_t *in = (uint64_t*)src;
+
+	uint64_t v0 = k0 ^ 0x736f6d6570736575ULL;
+	uint64_t v1 = k1 ^ 0x646f72616e646f6dULL;
+	uint64_t v2 = k0 ^ 0x6c7967656e657261ULL;
+	uint64_t v3 = k1 ^ 0x7465646279746573ULL;
+
+	while (src_sz >= 8) {
+		uint64_t mi = _le64toh(*in);
+		in += 1; src_sz -= 8;
+		v3 ^= mi;
+		DOUBLE_ROUND(v0,v1,v2,v3);
+		v0 ^= mi;
+	}
+
+	uint64_t t = 0; uint8_t *pt = (uint8_t *)&t; uint8_t *m = (uint8_t *)in;
+	switch (src_sz) {
+	case 7: pt[6] = m[6];
+	case 6: pt[5] = m[5];
+	case 5: pt[4] = m[4];
+	case 4: *((uint32_t*)&pt[0]) = *((uint32_t*)&m[0]); break;
+	case 3: pt[2] = m[2];
+	case 2: pt[1] = m[1];
+	case 1: pt[0] = m[0];
+	}
+	b |= _le64toh(t);
+
+	v3 ^= b;
+	DOUBLE_ROUND(v0,v1,v2,v3);
+	v0 ^= b; v2 ^= 0xff;
+	DOUBLE_ROUND(v0,v1,v2,v3);
+	DOUBLE_ROUND(v0,v1,v2,v3);
+	return (v0 ^ v1) ^ (v2 ^ v3);
+}

--- a/Firmware code/smart_energy_meter/lib/opaygo_decoder/siphash.h
+++ b/Firmware code/smart_energy_meter/lib/opaygo_decoder/siphash.h
@@ -1,0 +1,8 @@
+#ifndef siphash_h
+#define siphash_h
+
+#include <stdio.h>
+
+uint64_t siphash24(const void *src, unsigned long src_sz, unsigned char key[16]);
+
+#endif


### PR DESCRIPTION
From this commit: https://github.com/EnAccess/OpenPAYGO-HW/tree/875a013

This can be used in the OpenSmartMeter like so

```cpp
extern "C" {
#include <opaygo_core.h>
#include <opaygo_decoder.h>
}

uint32_t LastToken = 1234;
unsigned char SECRET_KEY[16] = {0xa2, 0x9a, 0xb8, 0x2e, 0xdc, 0x5f, 0xbb, 0xc4,
                                0x1e, 0xc9, 0x53, 0xf,  0x6d, 0xac, 0x86, 0xb1};
uint32_t test = GenerateOPAYGOToken(LastToken, SECRET_KEY);

uint64_t InputToken = 123124;
uint32_t StartingCode = 123;
uint16_t MaxCount = 10;
uint16_t UsedCounts = 5;
TokenData bluu = GetDataFromToken(InputToken, &MaxCount, &UsedCounts,
                                  StartingCode, SECRET_KEY);
```

Resolves: https://github.com/EnAccess/OpenSmartMeter/issues/61