### PR TITLE
Adjust PCB board thickness to 1.6

### DIFF
--- a/Meter hardware design/PCB CAD Design/EnAcess PCB.kicad_pcb
+++ b/Meter hardware design/PCB CAD Design/EnAcess PCB.kicad_pcb
@@ -1,7 +1,7 @@
 (kicad_pcb (version 20221018) (generator pcbnew)
 
   (general
-    (thickness 0)
+    (thickness 1.6)
   )
 
   (paper "A4")
@@ -38,6 +38,19 @@
   )
 
   (setup
+    (stackup
+      (layer "F.SilkS" (type "Top Silk Screen"))
+      (layer "F.Paste" (type "Top Solder Paste"))
+      (layer "F.Mask" (type "Top Solder Mask") (thickness 0.01))
+      (layer "F.Cu" (type "copper") (thickness 0.035))
+      (layer "dielectric 1" (type "core") (thickness 1.51) (material "FR4") (epsilon_r 4.5) (loss_tangent 0.02))
+      (layer "B.Cu" (type "copper") (thickness 0.035))
+      (layer "B.Mask" (type "Bottom Solder Mask") (thickness 0.01))
+      (layer "B.Paste" (type "Bottom Solder Paste"))
+      (layer "B.SilkS" (type "Bottom Silk Screen"))
+      (copper_finish "None")
+      (dielectric_constraints no)
+    )
     (pad_to_mask_clearance 0)
     (pcbplotparams
       (layerselection 0x00010fc_ffffffff)


### PR DESCRIPTION
Resolves: #108 

![image](https://github.com/EnAccess/OpenSmartMeter/assets/14202480/629126d1-32c7-4729-be7e-7dc65147bfad)

> Based on the capability of PCBWAY, the minimum thickness they can do is 0.2mm but the default setting is 1.6mm when you are making the order. I think you can set it to 1.6mm