### PR TITLE
Replace Demo video from repo with YouTube

### DIFF
--- a/docs/backend/api-documentation.md
+++ b/docs/backend/api-documentation.md
@@ -18,6 +18,27 @@ This document provides details on how to integrate ThingsBoard API to developers
 <source src="https://enaccess.github.io/OpenSmartMeter/assets/backend/webdemo_screen_record.mp4" type="video/mp4">
 </video>
 
+<style>
+  .youtube-embed-container {
+    position: relative;
+    padding-bottom: 56.25%;
+    height: 0;
+    overflow:
+    hidden; max-width: 100%;
+  }
+  .youtube-embed-container iframe,
+  .youtube-embed-container object,
+  .youtube-embed-container embed { position: absolute; top: 0; left: 0; width: 100%; height: 100%; }
+</style>
+<div class="youtube-embed-container">
+  <iframe
+    src="https://www.youtube.com/embed/A8EmnRPDZHc?enablejsapi=1"
+    frameborder="0"
+    allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share"
+    allowfullscreen>
+  </iframe>
+</div>
+
 ## ThingsBoard API integration:
 
 ThingsBoard is an open-source server-side platform that allows you to monitor and control IOT devices. It is free for both personal and commercial use and can be deployed anywhere. Steps to set up a ThingsBoard page is highlighted below:

--- a/docs/backend/api-documentation.md
+++ b/docs/backend/api-documentation.md
@@ -14,10 +14,6 @@ This document provides details on how to integrate ThingsBoard API to developers
 
 ## Screen Recording Demo
 
-<video controls>
-<source src="https://enaccess.github.io/OpenSmartMeter/assets/backend/webdemo_screen_record.mp4" type="video/mp4">
-</video>
-
 <style>
   .youtube-embed-container {
     position: relative;
@@ -32,7 +28,7 @@ This document provides details on how to integrate ThingsBoard API to developers
 </style>
 <div class="youtube-embed-container">
   <iframe
-    src="https://www.youtube.com/embed/A8EmnRPDZHc?enablejsapi=1"
+    src="https://www.youtube.com/embed/Pm6gHKM-Btc?enablejsapi=1"
     frameborder="0"
     allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share"
     allowfullscreen>


### PR DESCRIPTION
The video never changes, no point tracking it in Git.

Also, for YouTube videos we get GA4 integration out-of-the-box.

<img width="653" alt="image" src="https://github.com/EnAccess/OpenSmartMeter/assets/14202480/8fb6283a-e26b-474b-8e5e-b00b0a74d860">
